### PR TITLE
Multi-stem tensor fix, input length=output length option, MLP depth adjustment

### DIFF
--- a/bs_roformer/mel_band_roformer.py
+++ b/bs_roformer/mel_band_roformer.py
@@ -188,7 +188,7 @@ def MLP(
     dim_hidden = default(dim_hidden, dim_in)
 
     net = []
-    dims = (dim_in, *((dim_hidden,) * (depth - 1)), dim_out)
+    dims = (dim_in, *((dim_hidden,) * depth), dim_out)
 
     for ind, (layer_dim_in, layer_dim_out) in enumerate(zip(dims[:-1], dims[1:])):
         is_last = ind == (len(dims) - 2)
@@ -263,7 +263,7 @@ class MelBandRoformer(Module):
         stft_hop_length = 512,   # 10ms at 44100Hz, from sections 4.1, 4.4 in the paper - @faroit recommends // 2 or // 4 for better reconstruction
         stft_win_length = 2048,
         stft_normalized = False,
-        mask_estimator_depth = 2,
+        mask_estimator_depth = 1, # Number of hidden layers in each of the mask estimator MLPs
         multi_stft_resolution_loss_weight = 1.,
         multi_stft_resolutions_window_sizes: Tuple[int, ...] = (4096, 2048, 1024, 512, 256),
         multi_stft_hop_size = 147,


### PR DESCRIPTION
Changes:
- Added option to output a tensor the same length as input tensor.
   - Implemented via padding in the `torch.istft` function.
   - When utilizing an external method for calculating loss, this helps when comparing input & output audio.
- Tensor shape fixes for multi-stem training.
   - Training on a single stem worked, but I ran into tensor shape issues when I tried to add stems.
- Removed subtraction in MLP `dims` calculation to align `mask_estimator_depth` and MLP `depth` to be equal to the number of MLP hidden layers.
   - The `mask_estimator_depth=2` attribute seemed misleading when it resulted in an MLP depth of 3 layers (1 in, 1 hidden, 1 out). The default value for the MLP `depth` was 1 and `mask_estimator_depth` was 2. Now these are aligned to both be 1 and the attribute directly corresponds to the number of hidden layers in the MLPs.
   - Also, I believe that the MLPs only have 1 hidden layer per the BS-RoFormer paper (please correct me if I am incorrect!).